### PR TITLE
Remove verison number from MoveIt Pro because we release every 2 weeks

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,9 +12,9 @@
           >
         </p>
         <p>
-          Check out our
+          Check out 
           <a href="https://picknik.ai/pro/" target="_blank"
-            >MoveIt Pro Developer Platform</a
+            >MoveIt Pro</a
           >
         </p>
         <a class="button" href="/install">INSTALL NOW</a>

--- a/index.markdown
+++ b/index.markdown
@@ -361,7 +361,7 @@ redirect_from: '/moveit/'
                   </div>
                   <div class="release-versions__content">
                     <div class="release-versions__1">
-                      <h3>MoveIt Pro 5.0</h3>
+                      <h3>MoveIt Pro</h3>
                       <p>
                         <a href="https://picknik.ai/pro/" target="_blank">View product page</a>
                       </p>


### PR DESCRIPTION
### Description

We are now on v8.4 not 5.0 and don't have a simple way to automate keeping it up to date every 2 weeks.